### PR TITLE
Include option in API to not compress checkpointed archives

### DIFF
--- a/cmd/podman/containers/checkpoint.go
+++ b/cmd/podman/containers/checkpoint.go
@@ -53,11 +53,13 @@ func init() {
 	flags.BoolVarP(&checkpointOptions.All, "all", "a", false, "Checkpoint all running containers")
 
 	exportFlagName := "export"
-	flags.StringVarP(&checkpointOptions.Export, exportFlagName, "e", "", "Export the checkpoint image to a tar.gz")
+	flags.StringVarP(&checkpointOptions.Export, exportFlagName, "e", "", "Export the checkpoint image to a tar")
 	_ = checkpointCommand.RegisterFlagCompletionFunc(exportFlagName, completion.AutocompleteDefault)
 
 	flags.BoolVar(&checkpointOptions.IgnoreRootFS, "ignore-rootfs", false, "Do not include root file-system changes when exporting")
 	validate.AddLatestFlag(checkpointCommand, &checkpointOptions.Latest)
+
+	flags.StringVarP(&checkpointOptions.Compression, "compression", "c", "gzip", "Compress image using specified algorithm")
 }
 
 func checkpoint(cmd *cobra.Command, args []string) error {

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -677,6 +677,9 @@ type ContainerCheckpointOptions struct {
 	// important to be able to restore a container multiple
 	// times with '--import --name'.
 	IgnoreStaticMAC bool
+	// Compression tells the API whether to use Gzip compression 
+	// for exported containers
+	Compression string
 }
 
 // Checkpoint checkpoints a container

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -171,6 +171,7 @@ type CheckpointOptions struct {
 	Latest         bool
 	LeaveRunning   bool
 	TCPEstablished bool
+	Compression    string
 }
 
 type CheckpointReport struct {

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -492,6 +492,7 @@ func (ic *ContainerEngine) ContainerCheckpoint(ctx context.Context, namesOrIds [
 		TargetFile:     options.Export,
 		IgnoreRootfs:   options.IgnoreRootFS,
 		KeepRunning:    options.LeaveRunning,
+		Compression:    options.Compression,
 	}
 
 	if options.All {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read our contributing guidelines and how to submit a pull request (https://github.com/containers/podman/blob/master/CONTRIBUTING.md#submitting-pull-requests).

In case you're only changing docs, make sure to prefix the pull-request title with "[CI:DOCS]".  That will prevent functional tests from running and save time and energy.
-->

This PR adds the ability to specify whether to compress exported container checkpoint archives. Right now this is implemented in the command line and not in the REST/Varlink APIs. Example usage:
```
$ podman container checkpoint --export /path/to/file.tar --compression none <container-id> 
```
The `--compression` flag defaults to `gzip` to retain prior API behavior.